### PR TITLE
Impl Copy for Next

### DIFF
--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -21,7 +21,9 @@ impl<C: HttpClient> Middleware<C> for Doubler {
             *new_req.headers_mut() = req.headers().clone();
             Box::pin(async move {
                 let mut buf = Vec::new();
-                let (res1, res2) = futures::future::join(next.run(req, client.clone()), next.run(new_req, client)).await;
+                let (res1, res2) =
+                    futures::future::join(next.run(req, client.clone()), next.run(new_req, client))
+                        .await;
 
                 let res = res1?;
                 let mut body = res.into_body();

--- a/examples/next_reuse.rs
+++ b/examples/next_reuse.rs
@@ -1,0 +1,54 @@
+#![feature(async_await)]
+
+use futures::future::BoxFuture;
+use futures::io::AsyncReadExt;
+use surf::middleware::{Body, HttpClient, Middleware, Next, Request, Response};
+
+struct Doubler;
+
+impl<C: HttpClient> Middleware<C> for Doubler {
+    fn handle<'a>(
+        &'a self,
+        req: Request,
+        client: C,
+        next: Next<'a, C>,
+    ) -> BoxFuture<'a, Result<Response, surf::Exception>> {
+        if req.method().is_safe() {
+            let mut new_req = Request::new(Body::empty());
+            *new_req.method_mut() = req.method().clone();
+            *new_req.uri_mut() = req.uri().clone();
+            *new_req.version_mut() = req.version().clone();
+            *new_req.headers_mut() = req.headers().clone();
+            Box::pin(async move {
+                let mut buf = Vec::new();
+                let (res1, res2) = futures::future::join(next.run(req, client.clone()), next.run(new_req, client)).await;
+
+                let res = res1?;
+                let mut body = res.into_body();
+                body.read_to_end(&mut buf).await?;
+
+                let mut res = res2?;
+                let mut body = std::mem::replace(res.body_mut(), Body::empty());
+                body.read_to_end(&mut buf).await?;
+
+                *res.body_mut() = Body::from(buf);
+                Ok(res)
+            })
+        } else {
+            next.run(req, client)
+        }
+    }
+}
+
+#[runtime::main]
+async fn main() -> Result<(), surf::Exception> {
+    femme::start(log::LevelFilter::Info)?;
+    let mut res = surf::get("https://httpbin.org/get")
+        .middleware(Doubler {})
+        .await?;
+    dbg!(&res);
+    let body = res.body_bytes().await?;
+    let body = String::from_utf8_lossy(&body);
+    println!("{}", body);
+    Ok(())
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -96,6 +96,17 @@ pub struct Next<'a, C: HttpClient> {
              + Sync),
 }
 
+impl<C: HttpClient> Clone for Next<'_, C> {
+    fn clone(&self) -> Self {
+        Self {
+            next_middleware: self.next_middleware,
+            endpoint: self.endpoint,
+        }
+    }
+}
+
+impl<C: HttpClient> Copy for Next<'_, C> {}
+
 impl<'a, C: HttpClient> Next<'a, C> {
     /// Create a new instance
     pub fn new(


### PR DESCRIPTION
## Description
Make `Next` copy-able.

## Motivation and Context
Resolves #32.

Sometimes it's necessary to call remaining middleware chain multiple times. Making `Next` copy-able allows us run the chain again.

## How Has This Been Tested?
No automated tests; an example was added. All existing tests passed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
