### PR TITLE
Correct crate URL (from 'tide' to 'surf')

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <div align="center">
   <!-- Crates version -->
-  <a href="https://crates.io/crates/tide">
+  <a href="https://crates.io/crates/surf">
     <img src="https://img.shields.io/crates/v/surf.svg?style=flat-square"
     alt="Crates.io version" />
   </a>


### PR DESCRIPTION
Fixes what is presumably still a leftover from copy-pasting the `README.md` located in the [`tide`](https://github.com/rustasync/tide) repository 😉

Fixes #38.

(I'm deeply sorry that I didn't use the PR template, but I felt it was maybe a bit overkill for this rather minor change 😅)