### PR TITLE
Only require the http2 feature from chttp.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ url = "2.0.0"
 
 # chttp-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-chttp = { version = "0.5.3", optional = true }
+chttp = { version = "0.5.3", optional = true, default-features = false, features = ["http2"] }
 
 # hyper-client
 hyper = { version = "0.12.32", optional = true, default-features = false }


### PR DESCRIPTION
Default features includes always statically linking curl, which fails under macOS.
Not requiring static linking does the right thing on all OSs:

* Link against a system library if it exists (e.g. on Linux and macOS)
* Statically build and link against curl if it doesn't (e.g. on Windows)