### PR TITLE
Fix query string does not get sent

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -156,6 +156,7 @@ impl<C: HttpClient> Request<C> {
     /// let query = Index { page: 2 };
     /// let req = surf::get("https://httpbin.org/get").set_query(&query)?;
     /// assert_eq!(req.url().query(), Some("page=2"));
+    /// assert_eq!(format!("{}", req.request().unwrap().uri()), "https://httpbin.org/get?page=2");
     /// # Ok(()) }
     /// ```
     pub fn set_query(
@@ -164,6 +165,11 @@ impl<C: HttpClient> Request<C> {
     ) -> Result<Self, serde_urlencoded::ser::Error> {
         let query = serde_urlencoded::to_string(query)?;
         self.url.set_query(Some(&query));
+
+        let req = self.req.as_mut().unwrap();
+        let uri = req.uri_mut();
+        *uri = self.url.clone().into_string().parse().unwrap();
+
         Ok(self)
     }
 
@@ -567,6 +573,11 @@ impl<C: HttpClient> Request<C> {
     pub async fn recv_form<T: serde::de::DeserializeOwned>(self) -> Result<T, Exception> {
         let mut req = self.await?;
         Ok(req.body_form::<T>().await?)
+    }
+
+    /// Get a HTTP request
+    pub fn request(&self) -> Option<&http_client::Request> {
+        self.req.as_ref()
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix query string does not get sent

The `Response` structure has a` url` field, but `http_client :: Response` in the` req` field also has a url.
So there is a gap between the two.
Shouldn't it match one or the other?
I think it's better to have it in `http_client :: Response`.
Although this PR is an immediate implementation...
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

close: https://github.com/rustasync/surf/issues/48

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run `cargo run`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
