### PR TITLE
Update version of futures-preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ wasm-client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 middleware-logger = []
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.17", features = ["compat", "io-compat"] }
+futures-preview = { version = "0.3.0-alpha.18", features = ["compat", "io-compat"] }
 http = "0.1.17"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"


### PR DESCRIPTION
Update version of futures-preview

## Description
This change bumps the version of the `futures-preview` crate from `0.3.0-alpha.17` to `0.3.0-alpha.18`.

## Motivation and Context
There was some discussion in the `nushell` repo about removing a dependency on `reqwest` and trying to use this library instead; however, this library conflicts with another library included in `nushell` with regards to the dependency on the the `futures-preview` crate.

Since `nushell` is already using the newer version, I thought it made sense to try upgrading the version used by this library.

## How Has This Been Tested?
I am running all of this on macos 10.14.5. All I have done to test is run `cargo test`. I was not sure what else to do and would be happy to do more testing if it is desireable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
