### PR TITLE
Expose header map via Headers::header_map

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -30,6 +30,11 @@ impl<'a> Headers<'a> {
     pub fn iter(&self) -> Iter<'_> {
         Iter(self.headers.iter())
     }
+
+    /// Get the underlying `http::HeaderMap`.
+    pub fn header_map(&mut self) -> &mut http::HeaderMap {
+        self.headers
+    }
 }
 
 impl<'a> IntoIterator for Headers<'a> {


### PR DESCRIPTION
Do we really need the closed wrapper anyway? `http::HeaderMap` seems pretty advanced on its own and it is a hard requirement for using [typed headers](https://docs.rs/headers/0.2.1/headers/trait.HeaderMapExt.html).