### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,53 +67,57 @@ quick script, or a cross-platform SDK, Surf will make it work.
 ## Examples
 
 ```rust
-# #[runtime::main]
-# async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-let mut res = surf::get("https://httpbin.org/get").await?;
-dbg!(res.body_string().await?);
-# Ok(()) }
+#[runtime::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let mut res = surf::get("https://httpbin.org/get").await?;
+    dbg!(res.body_string().await?);
+    Ok(()) 
+}
 ```
 
 It's also possible to skip the intermediate `Response`, and access the response
 type directly.
 
 ```rust
-# #[runtime::main]
-# async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-dbg!(surf::get("https://httpbin.org/get").recv_string().await?);
-# Ok(()) }
+#[runtime::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    dbg!(surf::get("https://httpbin.org/get").recv_string().await?);
+    Ok(()) 
+}
 ```
 
 Both sending and receiving JSON is real easy too.
 
 ```rust
-# use serde::{Deserialize, Serialize};
-# #[runtime::main]
-# async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-#[derive(Deserialize, Serialize)]
-struct Ip {
-    ip: String
+use serde::{Deserialize, Serialize};
+#[runtime::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    #[derive(Deserialize, Serialize)]
+    struct Ip {
+        ip: String
+    }
+
+    let uri = "https://httpbin.org/post";
+    let data = &Ip { ip: "129.0.0.1".into() };
+    let res = surf::post(uri).body_json(data)?.await?;
+    assert_eq!(res.status(), 200);
+
+    let uri = "https://api.ipify.org?format=json";
+    let Ip { ip } = surf::get(uri).recv_json().await?;
+    assert!(ip.len() > 10);
+    Ok(())
 }
-
-let uri = "https://httpbin.org/post";
-let data = &Ip { ip: "129.0.0.1".into() };
-let res = surf::post(uri).body_json(data)?.await?;
-assert_eq!(res.status(), 200);
-
-let uri = "https://api.ipify.org?format=json";
-let Ip { ip } = surf::get(uri).recv_json().await?;
-assert!(ip.len() > 10);
-# Ok(()) }
 ```
 
 And even creating streaming proxies is no trouble at all.
 
 ```rust
-# #[runtime::main]
-# async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-let reader = surf::get("https://img.fyi/q6YvNqP").await?;
-let res = surf::post("https://box.rs/upload").body(reader).await?;
-# Ok(()) }
+#[runtime::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let reader = surf::get("https://img.fyi/q6YvNqP").await?;
+    let res = surf::post("https://box.rs/upload").body(reader).await?;
+    Ok(())
+}
 ```
 
 ## Installation


### PR DESCRIPTION
Fixed the indentation for code examples in the README. Removed pound signs from the beginning of the lines.

## Description
The code examples don't look great when rendered because of missing indentation and the pound signs at the beginning of the lines. Feel free to close this if there is intention behind it, but I figured if it was a mistake I would go ahead and correct it myself.

## Motivation and Context
It makes the code examples hard to read. The examples are a user's first impression of the library, so they should be readable and properly indented.

## How Has This Been Tested?
Rendered it on GitHub.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
