### PR TITLE
Typed headers support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ middleware-logger = []
 
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.18", features = ["compat", "io-compat"] }
+headers = "0.2"
 http = "0.1.17"
 log = { version = "0.4.7", features = ["kv_unstable"] }
 mime = "0.3.13"

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -19,11 +19,21 @@ impl<'a> Headers<'a> {
         self.headers.get(key).map(|h| h.to_str().unwrap())
     }
 
+    /// Get a typed header.
+    pub fn typed_get<H: headers::Header>(&self) -> Result<Option<H>, headers::Error> {
+        headers::HeaderMapExt::typed_try_get(self.headers)
+    }
+
     /// Set a header.
     pub fn insert(&mut self, key: &'static str, value: impl AsRef<str>) -> Option<String> {
         let value = value.as_ref().to_owned();
         let res = self.headers.insert(key, value.parse().unwrap());
         res.as_ref().map(|h| h.to_str().unwrap().to_owned())
+    }
+
+    /// Set a typed header.
+    pub fn typed_insert<H: headers::Header>(&mut self, header: H) {
+        headers::HeaderMapExt::typed_insert(self.headers, header)
     }
 
     /// Iterate over all headers.


### PR DESCRIPTION
# What is this?
This PR introduces support for hyper 0.11-style typed headers. They allow for strong typing of all common HTTP headers and their values.

# Implementation note
While I prefer that we expose `HeaderMap` directly, this plumbing brings typed headers support to the `Headers` wrapper directly.

In the future we could completely obsolete stringly typed headers thanks to the extensibility provided by the `Header` trait.